### PR TITLE
Restore null player in BlockPistonExtendEvent ObjectCheck

### DIFF
--- a/core/src/main/java/cn/superiormc/mythictotem/objects/checks/ObjectCheck.java
+++ b/core/src/main/java/cn/superiormc/mythictotem/objects/checks/ObjectCheck.java
@@ -86,7 +86,7 @@ public class ObjectCheck {
             return;
         }
         this.block = event.getBlocks().getLast().getRelative(event.getDirection()).getLocation().getBlock();
-        this.player = Bukkit.getPlayer("PQguanfang2");
+        this.player = null;
         this.item = null;
         checkTotem();
     }


### PR DESCRIPTION
### Motivation
- Remove a hardcoded player lookup in the `BlockPistonExtendEvent` constructor that caused the check logic to be bound to a specific user and created incorrect/fragile behavior when that user was not present.

### Description
- Replace `this.player = Bukkit.getPlayer("PQguanfang2");` with `this.player = null;` in `core/src/main/java/cn/superiormc/mythictotem/objects/checks/ObjectCheck.java` so piston-extend checks run with a neutral player context.

### Testing
- Ran `rg -n "PQguanfang2|Bukkit.getPlayer\\(" core/src/main/java` and inspected the updated lines with `nl -ba core/src/main/java/cn/superiormc/mythictotem/objects/checks/ObjectCheck.java | sed -n '84,96p'` to confirm the lookup was removed and the file shows `this.player = null;`; these checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa932641f48332a4b41c82da2ccf4f)